### PR TITLE
fix: throw error if workday in garbage

### DIFF
--- a/api/tests/workdays/create_workday.rs
+++ b/api/tests/workdays/create_workday.rs
@@ -201,7 +201,7 @@ async fn test_create_workday_duplicate_garbage(ctx: &mut context::TestContext) {
     res.assert_status(StatusCode::CONFLICT);
 
     let body: ErrorBody = res.json();
-    assert_eq!(body.error_code, "WORKDAY_ALREADY_EXISTS");
+    assert_eq!(body.error_code, "WORKDAY_GARBAGE_ALREADY_EXISTS");
 }
 
 #[test_context(context::TestContext)]

--- a/core/src/domain/workday/entities.rs
+++ b/core/src/domain/workday/entities.rs
@@ -70,7 +70,7 @@ pub struct GetWorkdaysByPeriodParams {
     pub limit: u32,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Clone, Copy, Validate, ToSchema)]
 pub struct CreateWorkdayRequest {
     #[validate(custom(
         function = "validate_date",

--- a/core/src/domain/workday/services.rs
+++ b/core/src/domain/workday/services.rs
@@ -165,10 +165,30 @@ where
         driver_id: Uuid,
         create_workday_request: CreateWorkdayRequest,
     ) -> Result<WorkdayRow, WorkdayError> {
-        let workday = self
+        let workday = match self
             .workday_database_repository
             .create_workday(driver_id, create_workday_request)
-            .await?;
+            .await
+        {
+            Ok(w) => w,
+            Err(WorkdayError::WorkdayAlreadyExists) => {
+                let has_garbage =
+                    self.get_workdays_garbage(driver_id)
+                        .await
+                        .ok()
+                        .and_then(|garbages| {
+                            garbages
+                                .into_iter()
+                                .find(|g| g.workday_date == create_workday_request.date)
+                        });
+                return Err(if has_garbage.is_some() {
+                    WorkdayError::WorkdayGarbageAlreadyExists
+                } else {
+                    WorkdayError::WorkdayAlreadyExists
+                });
+            }
+            Err(_) => return Err(WorkdayError::Internal),
+        };
 
         self.workday_cache_repository
             .delete_workdays_by_month(driver_id, workday.date.month() as i32, workday.date.year())


### PR DESCRIPTION
# Description

When creating a workday, we must detail two types of conflict:
1. When a workday already exists for this date.
2. When a workday is in garbage for this date.

Currently, we don't handle the garbage in conflicts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Create a workday
- [ ] Put this workday in the garbage
- [ ] Try to create another workday with the same date

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes