### PR TITLE
feat: add deactivated attribute to DriverClaims for JWT payload

### DIFF
--- a/api/src/http/common/middleware/auth/entities.rs
+++ b/api/src/http/common/middleware/auth/entities.rs
@@ -88,7 +88,7 @@ impl TokenValidator for AuthValidator {
                 last_name: driver.lastname.clone(),
                 email: driver.email.clone(),
                 verified: driver.verified_at.is_some(),
-                deactivation_planned_at: driver.deactivated_at.clone(),
+                deactivation_planned_at: driver.deactivated_at,
             },
             exp: access_exp,
             iat: now,

--- a/api/src/http/common/middleware/auth/entities.rs
+++ b/api/src/http/common/middleware/auth/entities.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use plannify_driver_api_core::domain::driver::entities::DriverRow;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -20,6 +20,7 @@ pub struct DriverClaims {
     pub last_name: String,
     pub email: String,
     pub verified: bool,
+    pub deactivation_planned_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -87,6 +88,7 @@ impl TokenValidator for AuthValidator {
                 last_name: driver.lastname.clone(),
                 email: driver.email.clone(),
                 verified: driver.verified_at.is_some(),
+                deactivation_planned_at: driver.deactivated_at.clone(),
             },
             exp: access_exp,
             iat: now,

--- a/api/tests/helpers/auth.rs
+++ b/api/tests/helpers/auth.rs
@@ -18,6 +18,7 @@ pub fn generate_mock_token(user_id: &Uuid) -> String {
             last_name: "User".to_string(),
             email: "test.user@example.com".to_string(),
             verified: true,
+            deactivation_planned_at: None,
         },
         exp: now + 3600, // Token expires in 1 hour
         iat: now,


### PR DESCRIPTION
# Description

Add the `deactivation_planned_at` attribute in the JWT payload.

Fixes #43 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Login in and see the JWT payload without deactivation date
- [ ] Deactivate your account
- [ ] Login in again and see the JWT payload **with** deactivation date

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes